### PR TITLE
Added lineEnding for formatter so it doesn't reformat all files under Windows

### DIFF
--- a/cobertura/pom.xml
+++ b/cobertura/pom.xml
@@ -225,6 +225,9 @@
         <groupId>com.googlecode.maven-java-formatter-plugin</groupId>
         <artifactId>maven-java-formatter-plugin</artifactId>
         <version>${plugin.java.formatter.version}</version>
+        <configuration>
+          <lineEnding>LF</lineEnding>
+        </configuration>
         <executions>
           <execution>
             <goals>


### PR DESCRIPTION
While playing with cobertura sources I got annoyed that formatter replaced LF with CRLF (due to me having Windows), making subsequent diffs one large mess.
