### PR TITLE
Simplified tools jar resolution.

### DIFF
--- a/cobertura/pom.xml
+++ b/cobertura/pom.xml
@@ -178,34 +178,22 @@
 
   <profiles>
     <profile>
-      <id>WindowsProfile</id>
+      <id>ClassesJar</id>
       <activation>
-        <os>
-          <family>Windows</family>
-        </os>
+        <file>
+          <exists>${java.home}/../Classes/classes.jar</exists>
+        </file>
       </activation>
       <properties>
-        <toolsjar>${java.home}/../lib/tools.jar</toolsjar>
+        <toolsjar>${java.home}/../Classes/classes.jar</toolsjar>
       </properties>
     </profile>
     <profile>
-      <id>UnixProfile</id>
+      <id>ToolsJar</id>
       <activation>
-        <os>
-          <family>unix</family>
-          <name>Linux</name>
-        </os>
-      </activation>
-      <properties>
-        <toolsjar>${java.home}/../lib/tools.jar</toolsjar>
-      </properties>
-    </profile>
-    <profile>
-      <id>OSXProfile</id>
-      <activation>
-        <os>
-          <family>mac</family>
-        </os>
+        <file>
+          <exists>${java.home}/../lib/tools.jar</exists>
+        </file>
       </activation>
       <properties>
         <toolsjar>${java.home}/../lib/tools.jar</toolsjar>


### PR DESCRIPTION
On OSX the Oracle JDK 6 ships with ../Classes/classes.jar but Oracle JDK 7 ships with ../lib/tools.jar. Until maven supports profile activation as the docs claim this seem to work.
Tested it with:
- compiles ok & tests pass on OS X 10.7 with Oracle JDK 7
- compiles ok but Java 7 specific tests fail on OS X 10.7 with JDK 6
- compiles ok & tests pass on Ubuntu 12 with Open JDK 7 & Oracle JDK 7 (https://travis-ci.org/decbis/cobertura/builds/11000007)
- compiles ok but Java 7 specific tests fail on Ubuntu 12.04 with OpenJDK 6 (https://travis-ci.org/decbis/cobertura/jobs/10999071)
