### PR TITLE
Created a static method that plugins can call that doesn't perform a Sys...

### DIFF
--- a/cobertura/src/main/java/net/sourceforge/cobertura/check/CheckCoverageMain.java
+++ b/cobertura/src/main/java/net/sourceforge/cobertura/check/CheckCoverageMain.java
@@ -48,6 +48,52 @@ public class CheckCoverageMain {
 			.getLogger(CheckCoverageMain.class);
 
 	public CheckCoverageMain(String[] args) throws MalformedPatternException {
+		int exitStatus = checkCoverage(args);
+		System.exit(exitStatus);
+	}
+
+	private static int checkCoverageTypeStatusAndLogMessage(
+			CoverageResultEntry entry, int branchStatus, int lineStatus) {
+		if (entry.getCoverageType().equals(BRANCH)) {
+			logger
+					.error(String
+							.format(
+									"%s failed coverage check. Branch coverage rate of %s is below %s",
+									entry.getName(),
+									entry.getCurrentCoverage(), entry
+											.getExpectedCoverage()));
+			return branchStatus;
+		} else {
+			logger
+					.error(String
+							.format(
+									"%s failed coverage check. Line coverage rate of %s is below %s",
+									entry.getName(),
+									entry.getCurrentCoverage(), entry
+											.getExpectedCoverage()));
+			return lineStatus;
+		}
+	}
+
+	private static double inRangeAndDivideByOneHundred(
+			String coverageRateAsPercentage) {
+		return inRangeAndDivideByOneHundred(Integer
+				.valueOf(coverageRateAsPercentage));
+	}
+
+	private static double inRangeAndDivideByOneHundred(
+			int coverageRateAsPercentage) {
+		if ((coverageRateAsPercentage >= 0)
+				&& (coverageRateAsPercentage <= 100)) {
+			return (double) coverageRateAsPercentage / 100;
+		}
+		throw new IllegalArgumentException("The value "
+				+ coverageRateAsPercentage
+				+ "% is invalid.  Percentages must be between 0 and 100.");
+	}
+
+	public static int checkCoverage(String[] args)
+			throws MalformedPatternException {
 		Header.print(System.out);
 
 		ArgumentsBuilder builder = new ArgumentsBuilder();
@@ -108,48 +154,11 @@ public class CheckCoverageMain {
 				}
 			}
 		}
-		System.exit(exitStatus);
-	}
-
-	private int checkCoverageTypeStatusAndLogMessage(CoverageResultEntry entry,
-			int branchStatus, int lineStatus) {
-		if (entry.getCoverageType().equals(BRANCH)) {
-			logger
-					.error(String
-							.format(
-									"%s failed coverage check. Branch coverage rate of %s is below %s",
-									entry.getName(),
-									entry.getCurrentCoverage(), entry
-											.getExpectedCoverage()));
-			return branchStatus;
-		} else {
-			logger
-					.error(String
-							.format(
-									"%s failed coverage check. Line coverage rate of %s is below %s",
-									entry.getName(),
-									entry.getCurrentCoverage(), entry
-											.getExpectedCoverage()));
-			return lineStatus;
-		}
-	}
-
-	private double inRangeAndDivideByOneHundred(String coverageRateAsPercentage) {
-		return inRangeAndDivideByOneHundred(Integer
-				.valueOf(coverageRateAsPercentage));
-	}
-
-	private double inRangeAndDivideByOneHundred(int coverageRateAsPercentage) {
-		if ((coverageRateAsPercentage >= 0)
-				&& (coverageRateAsPercentage <= 100)) {
-			return (double) coverageRateAsPercentage / 100;
-		}
-		throw new IllegalArgumentException("The value "
-				+ coverageRateAsPercentage
-				+ "% is invalid.  Percentages must be between 0 and 100.");
+		return exitStatus;
 	}
 
 	public static void main(String[] args) throws MalformedPatternException {
-		new CheckCoverageMain(args);
+		int exitStatus = checkCoverage(args);
+		System.exit(exitStatus);
 	}
 }


### PR DESCRIPTION
The class that performs a coverage check uses `System.exit`, which creates challenges for plugin authors.  For example, in the Gradle cobertura plugin, we want to check coverage, but we don't want the build to fail when the coverage levels are too low - especially when the user has chosen to use the ``coverageCheckHaltOnFailure = false`  option.

The change I'm proposing creates a new method that does the work of the check but does not exit.  Plugins can invoke this method to get a result.  The `main` method currently calls this new method and does a `System.exit` with the result for backwards compatibility.  The class constructor is not really needed anymore, but it could be kept in case anyone is using it directly.

Also:  I noticed that all the `Main` classes for instrumentation, reporting, etc have changed names. This will cause any code trying to access Cobertura classes, such as existing plugins, to break when 2.0.4 is released.  It might be a good idea to restore those class names to `Main`.  This is particularly useful for plugins that are not tied to a particular Cobertura version.
