### PR TITLE
Fixed classpaths in scripts.

### DIFF
--- a/cobertura/executables/cobertura-check.bat
+++ b/cobertura/executables/cobertura-check.bat
@@ -18,4 +18,4 @@ shift
 goto getArgs
 :doneStart
 
-java -cp "%COBERTURA_HOME%cobertura.jar;%COBERTURA_HOME%lib\asm-3.3.1.jar;%COBERTURA_HOME%lib\asm-tree-3.3.1.jar;%COBERTURA_HOME%lib\asm-commons-3.3.1.jar;%COBERTURA_HOME%lib\log4j-1.2.9.jar;%COBERTURA_HOME%lib\jakarta-oro-2.0.8.jar" net.sourceforge.cobertura.check.CheckCoverageMain %CMD_LINE_ARGS%
+java -cp "%COBERTURA_HOME%cobertura.jar;%COBERTURA_HOME%lib\asm-4.1.jar;%COBERTURA_HOME%lib\asm-util-4.1.jar;%COBERTURA_HOME%lib\asm-tree-4.1.jar;%COBERTURA_HOME%lib\asm-commons-4.1.jar;%COBERTURA_HOME%lib\asm-analysis-4.1.jar;%COBERTURA_HOME%lib\log4j-1.2.9.jar;%COBERTURA_HOME%lib\oro-2.0.8.jar" net.sourceforge.cobertura.check.CheckCoverageMain %CMD_LINE_ARGS%

--- a/cobertura/executables/cobertura-check.sh
+++ b/cobertura/executables/cobertura-check.sh
@@ -1,1 +1,2 @@
-java -cp `dirname $0`/cobertura.jar:`dirname $0`/lib/asm-3.3.1.jar:`dirname $0`/lib/asm-tree-3.3.1.jar:`dirname $0`/lib/asm-commons-3.3.1.jar:`dirname $0`/lib/log4j-1.2.9.jar:`dirname $0`/lib/jakarta-oro-2.0.8.jar net.sourceforge.cobertura.check.CheckCoverageMain $*
+DIR=`dirname $0`
+java -cp $DIR/cobertura-2.0.3.jar:$DIR/lib/asm-4.1.jar:$DIR/lib/asm-util-4.1.jar:$DIR/lib/asm-tree-4.1.jar:$DIR/lib/asm-commons-4.1.jar:$DIR/lib/asm-analysis-4.1.jar:$DIR/lib/log4j-1.2.9.jar:$DIR/lib/oro-2.0.8.jar net.sourceforge.cobertura.check.CheckCoverageMain $*

--- a/cobertura/executables/cobertura-instrument.sh
+++ b/cobertura/executables/cobertura-instrument.sh
@@ -1,1 +1,2 @@
-java -cp `dirname $0`/cobertura.jar:`dirname $0`/lib/asm-3.3.1.jar:`dirname $0`/lib/asm-tree-3.3.1.jar:`dirname $0`/lib/asm-commons-3.3.1.jar:`dirname $0`/lib/log4j-1.2.9.jar:`dirname $0`/lib/jakarta-oro-2.0.8.jar net.sourceforge.cobertura.instrument.InstrumentMain $*
+DIR=`dirname $0`
+java -cp $DIR/cobertura-2.0.3.jar:$DIR/lib/asm-4.1.jar:$DIR/lib/asm-util-4.1.jar:$DIR/lib/asm-tree-4.1.jar:$DIR/lib/asm-commons-4.1.jar:$DIR/lib/asm-analysis-4.1.jar:$DIR/lib/log4j-1.2.9.jar:$DIR/lib/oro-2.0.8.jar net.sourceforge.cobertura.instrument.InstrumentMain $*

--- a/cobertura/executables/cobertura-merge.bat
+++ b/cobertura/executables/cobertura-merge.bat
@@ -18,4 +18,4 @@ shift
 goto getArgs
 :doneStart
 
-java -cp "%COBERTURA_HOME%cobertura.jar;%COBERTURA_HOME%lib\asm-3.3.1.jar;%COBERTURA_HOME%lib\asm-tree-3.3.1.jar;%COBERTURA_HOME%lib\asm-commons-3.3.1.jar;%COBERTURA_HOME%lib\log4j-1.2.9.jar;%COBERTURA_HOME%lib\jakarta-oro-2.0.8.jar" net.sourceforge.cobertura.merge.MergeMain %CMD_LINE_ARGS%
+java -cp "%COBERTURA_HOME%cobertura.jar;%COBERTURA_HOME%lib\asm-4.1.jar;%COBERTURA_HOME%lib\asm-util-4.1.jar;%COBERTURA_HOME%lib\asm-tree-4.1.jar;%COBERTURA_HOME%lib\asm-commons-4.1.jar;%COBERTURA_HOME%lib\asm-analysis-4.1.jar;%COBERTURA_HOME%lib\log4j-1.2.9.jar;%COBERTURA_HOME%lib\oro-2.0.8.jar" net.sourceforge.cobertura.merge.MergeMain %CMD_LINE_ARGS%

--- a/cobertura/executables/cobertura-merge.sh
+++ b/cobertura/executables/cobertura-merge.sh
@@ -1,1 +1,2 @@
-java -cp `dirname $0`/cobertura.jar:`dirname $0`/lib/asm-3.3.1.jar:`dirname $0`/lib/asm-tree-3.3.1.jar:`dirname $0`/lib/asm-commons-3.3.1.jar:`dirname $0`/lib/log4j-1.2.9.jar:`dirname $0`/lib/jakarta-oro-2.0.8.jar net.sourceforge.cobertura.merge.MergeMain $*
+DIR=`dirname $0`
+java -cp $DIR/cobertura-2.0.3.jar:$DIR/lib/asm-4.1.jar:$DIR/lib/asm-util-4.1.jar:$DIR/lib/asm-tree-4.1.jar:$DIR/lib/asm-commons-4.1.jar:$DIR/lib/asm-analysis-4.1.jar:$DIR/lib/log4j-1.2.9.jar:$DIR/lib/oro-2.0.8.jar net.sourceforge.cobertura.merge.MergeMain $*

--- a/cobertura/executables/cobertura-report.bat
+++ b/cobertura/executables/cobertura-report.bat
@@ -18,4 +18,4 @@ shift
 goto getArgs
 :doneStart
 
-java -cp "%COBERTURA_HOME%cobertura.jar;%COBERTURA_HOME%lib\asm-3.3.1.jar;%COBERTURA_HOME%lib\asm-tree-3.3.1.jar;%COBERTURA_HOME%lib\asm-commons-3.3.1.jar;%COBERTURA_HOME%lib\log4j-1.2.9.jar;%COBERTURA_HOME%lib\jakarta-oro-2.0.8.jar" net.sourceforge.cobertura.reporting.ReportMain %CMD_LINE_ARGS%
+java -cp "%COBERTURA_HOME%cobertura.jar;%COBERTURA_HOME%lib\asm-4.1.jar;%COBERTURA_HOME%lib\asm-util-4.1.jar;%COBERTURA_HOME%lib\asm-tree-4.1.jar;%COBERTURA_HOME%lib\asm-commons-4.1.jar;%COBERTURA_HOME%lib\asm-analysis-4.1.jar;%COBERTURA_HOME%lib\log4j-1.2.9.jar;%COBERTURA_HOME%lib\oro-2.0.8.jar" net.sourceforge.cobertura.reporting.ReportMain %CMD_LINE_ARGS%

--- a/cobertura/executables/cobertura-report.sh
+++ b/cobertura/executables/cobertura-report.sh
@@ -1,1 +1,2 @@
-java -cp `dirname $0`/cobertura.jar:`dirname $0`/lib/asm-3.3.1.jar:`dirname $0`/lib/asm-tree-3.3.1.jar:`dirname $0`/lib/asm-commons-3.3.1.jar:`dirname $0`/lib/log4j-1.2.9.jar:`dirname $0`/lib/jakarta-oro-2.0.8.jar net.sourceforge.cobertura.reporting.ReportMain $*
+DIR=`dirname $0`
+java -cp $DIR/cobertura-2.0.3.jar:$DIR/lib/asm-4.1.jar:$DIR/lib/asm-util-4.1.jar:$DIR/lib/asm-tree-4.1.jar:$DIR/lib/asm-commons-4.1.jar:$DIR/lib/asm-analysis-4.1.jar:$DIR/lib/log4j-1.2.9.jar:$DIR/lib/oro-2.0.8.jar net.sourceforge.cobertura.reporting.ReportMain $*


### PR DESCRIPTION
All scripts except `cobertura-insturment.bat` had wrong classpath's defined; this commit fixes that.
