### PR TITLE
Ignore class annotations support added. Matched classes won't be instrumented

### DIFF
--- a/cobertura/src/main/java/net/sourceforge/cobertura/ant/IgnoreClassAnnotation.java
+++ b/cobertura/src/main/java/net/sourceforge/cobertura/ant/IgnoreClassAnnotation.java
@@ -1,0 +1,70 @@
+/*
+ * The Apache Software License, Version 1.1
+ *
+ * Copyright (C) 2000-2002 The Apache Software Foundation.  All rights
+ * reserved.
+ * Copyright (C) 2003 jcoverage ltd.
+ * Copyright (C) 2005 Mark Doliner
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *
+ * 3. The end-user documentation included with the redistribution, if
+ *    any, must include the following acknowlegement:
+ *       "This product includes software developed by the
+ *        Apache Software Foundation (http://www.apache.org/)."
+ *    Alternately, this acknowlegement may appear in the software itself,
+ *    if and wherever such third-party acknowlegements normally appear.
+ *
+ * 4. The names "Ant" and "Apache Software
+ *    Foundation" must not be used to endorse or promote products derived
+ *    from this software without prior written permission. For written
+ *    permission, please contact apache@apache.org.
+ *
+ * 5. Products derived from this software may not be called "Apache"
+ *    nor may "Apache" appear in their names without prior written
+ *    permission of the Apache Group.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED.  IN NO EVENT SHALL THE APACHE SOFTWARE FOUNDATION OR
+ * ITS CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ * USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ */
+
+package net.sourceforge.cobertura.ant;
+
+public class IgnoreClassAnnotation {
+	private String annotationName;
+
+	public String getAnnotationName() {
+		return annotationName;
+	}
+
+	public void setAnnotationName(String annotationName) {
+		this.annotationName = annotationName;
+	}
+
+}

--- a/cobertura/src/main/java/net/sourceforge/cobertura/ant/InstrumentTask.java
+++ b/cobertura/src/main/java/net/sourceforge/cobertura/ant/InstrumentTask.java
@@ -91,6 +91,8 @@ public class InstrumentTask extends CommonMatchingTask {
 
 	final List<IgnoreMethodAnnotation> ignoreMethodAnnotations = new ArrayList<IgnoreMethodAnnotation>();
 
+	final List<IgnoreClassAnnotation> ignoreClassAnnotations = new ArrayList<IgnoreClassAnnotation>();
+
 	final List<IncludeClasses> includeClassesRegexs = new ArrayList<IncludeClasses>();
 
 	final List<ExcludeClasses> excludeClassesRegexs = new ArrayList<ExcludeClasses>();
@@ -129,6 +131,12 @@ public class InstrumentTask extends CommonMatchingTask {
 		return ignoreAnnotation;
 	}
 
+	public IgnoreClassAnnotation createIgnoreClassAnnotation() {
+		IgnoreClassAnnotation ignoreAnnotation = new IgnoreClassAnnotation();
+		ignoreClassAnnotations.add(ignoreAnnotation);
+		return ignoreAnnotation;
+	}
+
 	public IncludeClasses createIncludeClasses() {
 		IncludeClasses includeClassesRegex = new IncludeClasses();
 		includeClassesRegexs.add(includeClassesRegex);
@@ -149,14 +157,12 @@ public class InstrumentTask extends CommonMatchingTask {
 	}
 
 	/*
-	 * TODO: Is the following method needed to use a classpath ref?  If so,
-	 *       test it and uncomment it.
+	 * TODO: Is the following method needed to use a classpath ref? If so, test
+	 * it and uncomment it.
 	 */
 	/*
-	public void setInstrumentationClasspathRef(Reference r)
-	{
-		createInstrumentationClasspath().setRefid(r);
-	}
+	 * public void setInstrumentationClasspathRef(Reference r) {
+	 * createInstrumentationClasspath().setRefid(r); }
 	 */
 
 	@Override
@@ -179,29 +185,36 @@ public class InstrumentTask extends CommonMatchingTask {
 			for (int i = 0; i < ignoreBranchesRegexs.size(); i++) {
 				IgnoreBranches ignoreBranchesRegex = ignoreBranchesRegexs
 						.get(i);
-				builder.addArg("--ignoreBranches", ignoreBranchesRegex
-						.getRegex());
+				builder.addArg("--ignoreBranches",
+						ignoreBranchesRegex.getRegex());
 			}
 
 			for (int i = 0; i < ignoreMethodAnnotations.size(); i++) {
 				IgnoreMethodAnnotation ignoreMethodAnn = ignoreMethodAnnotations
 						.get(i);
-				builder.addArg("--ignoreMethodAnnotation", ignoreMethodAnn
-						.getAnnotationName());
+				builder.addArg("--ignoreMethodAnnotation",
+						ignoreMethodAnn.getAnnotationName());
+			}
+
+			for (int i = 0; i < ignoreClassAnnotations.size(); i++) {
+				IgnoreClassAnnotation ignoreClassAnn = ignoreClassAnnotations
+						.get(i);
+				builder.addArg("--ignoreClassAnnotation",
+						ignoreClassAnn.getAnnotationName());
 			}
 
 			for (int i = 0; i < includeClassesRegexs.size(); i++) {
 				IncludeClasses includeClassesRegex = includeClassesRegexs
 						.get(i);
-				builder.addArg("--includeClasses", includeClassesRegex
-						.getRegex());
+				builder.addArg("--includeClasses",
+						includeClassesRegex.getRegex());
 			}
 
 			for (int i = 0; i < excludeClassesRegexs.size(); i++) {
 				ExcludeClasses excludeClassesRegex = excludeClassesRegexs
 						.get(i);
-				builder.addArg("--excludeClasses", excludeClassesRegex
-						.getRegex());
+				builder.addArg("--excludeClasses",
+						excludeClassesRegex.getRegex());
 			}
 
 			if (ignoreTrivial) {
@@ -254,8 +267,8 @@ public class InstrumentTask extends CommonMatchingTask {
 	}
 
 	/**
-	 * Creates a classpath to be used by the instrumenter because
-	 * asm uses Class.forName() in its own classpath to determine common super classes.
+	 * Creates a classpath to be used by the instrumenter because asm uses
+	 * Class.forName() in its own classpath to determine common super classes.
 	 */
 	private Path createClasspathForInstrumenter() {
 		Path path = (Path) createInstrumentationClasspath().clone();

--- a/cobertura/src/main/java/net/sourceforge/cobertura/dsl/Arguments.java
+++ b/cobertura/src/main/java/net/sourceforge/cobertura/dsl/Arguments.java
@@ -60,6 +60,7 @@ public class Arguments {
 	private Set<CoberturaFile> filesToInstrument;
 	private Set<File> filesToMerge;
 	private Set<String> ignoreMethodAnnotations;
+	private Set<String> ignoreClassAnnotations;
 
 	Arguments(File baseDirectory, File dataFile, File destinationDirectory,
 			File commandsFile, Collection ignoreRegexes,
@@ -73,7 +74,8 @@ public class Arguments {
 			double packageLineThreshold, double packageBranchThreshold,
 			double totalLineThreshold, double totalBranchThreshold,
 			Set<CoberturaFile> filesToInstrument, Set<File> filesToMerge,
-			Set<String> ignoreMethodAnnotations, FileFinder sources) {
+			Set<String> ignoreMethodAnnotations,
+			Set<String> ignoreClassAnnotations, FileFinder sources) {
 		this.baseDirectory = baseDirectory;
 		this.dataFile = dataFile;
 		this.destinationDirectory = destinationDirectory;
@@ -102,6 +104,8 @@ public class Arguments {
 		this.filesToMerge = Collections.unmodifiableSet(filesToMerge);
 		this.ignoreMethodAnnotations = Collections
 				.unmodifiableSet(ignoreMethodAnnotations);
+		this.ignoreClassAnnotations = Collections
+				.unmodifiableSet(ignoreClassAnnotations);
 	}
 
 	public File getBaseDirectory() {
@@ -194,5 +198,9 @@ public class Arguments {
 
 	public FileFinder getSources() {
 		return sources;
+	}
+
+	public Set<String> getIgnoreClassAnnotations() {
+		return ignoreClassAnnotations;
 	}
 }

--- a/cobertura/src/main/java/net/sourceforge/cobertura/dsl/ArgumentsBuilder.java
+++ b/cobertura/src/main/java/net/sourceforge/cobertura/dsl/ArgumentsBuilder.java
@@ -33,7 +33,7 @@ import java.util.*;
  * Arguments builder - provides a DSL to build cobertura Arguments
  */
 public class ArgumentsBuilder {
-	//Visible for testing
+	// Visible for testing
 	static final String DEFAULT_ENCODING = "UTF-8";
 	static final double DEFAULT_THRESHOLD = 0.;
 	static final boolean DEFAULT_FAIL_ON_ERROR = false;
@@ -69,6 +69,7 @@ public class ArgumentsBuilder {
 	private Set<CoberturaFile> filesToInstrument;
 	private Set<File> filesToMerge;
 	private Set<String> ignoreMethodAnnotations;
+	private Set<String> ignoreClassAnnotations;
 
 	public ArgumentsBuilder() {
 		initVariables();
@@ -107,6 +108,12 @@ public class ArgumentsBuilder {
 	public ArgumentsBuilder addIgnoreMethodAnnotation(
 			String ignoreMethodAnnotation) {
 		ignoreMethodAnnotations.add(ignoreMethodAnnotation);
+		return this;
+	}
+
+	public ArgumentsBuilder addIgnoreClassAnnotation(
+			String ignoreClassAnnotation) {
+		ignoreClassAnnotations.add(ignoreClassAnnotation);
 		return this;
 	}
 
@@ -227,7 +234,7 @@ public class ArgumentsBuilder {
 				classLineThreshold, classBranchThreshold, packageLineThreshold,
 				packageBranchThreshold, totalLineThreshold,
 				totalBranchThreshold, filesToInstrument, filesToMerge,
-				ignoreMethodAnnotations, sources);
+				ignoreMethodAnnotations, ignoreClassAnnotations, sources);
 	}
 
 	private double inRange(double coverageRate) {
@@ -245,14 +252,15 @@ public class ArgumentsBuilder {
 		ignoreRegexes = new Vector();
 		ignoreBranchesRegexes = new Vector<Pattern>();
 		ignoreMethodAnnotations = new HashSet<String>();
+		ignoreClassAnnotations = new HashSet<String>();
 		classPatternExcludeClassesRegexes = new HashSet<Pattern>();
 		classPatternIncludeClassesRegexes = new HashSet<Pattern>();
 		filesToInstrument = new HashSet<CoberturaFile>();
 		filesToMerge = new HashSet<File>();
 		minimumCoverageThresholds = new HashSet<CoverageThreshold>();
 
-		//previous rule was: default threshold is 0.5 for all
-		//if a threshold is specified, the others are defaulted to 0
+		// previous rule was: default threshold is 0.5 for all
+		// if a threshold is specified, the others are defaulted to 0
 		classBranchThreshold = DEFAULT_THRESHOLD;
 		classLineThreshold = DEFAULT_THRESHOLD;
 		packageBranchThreshold = DEFAULT_THRESHOLD;

--- a/cobertura/src/main/java/net/sourceforge/cobertura/instrument/CoberturaInstrumenter.java
+++ b/cobertura/src/main/java/net/sourceforge/cobertura/instrument/CoberturaInstrumenter.java
@@ -87,6 +87,12 @@ public class CoberturaInstrumenter {
 	private Set<String> ignoreMethodAnnotations = new HashSet<String>();
 
 	/**
+	 * Classes annotated by this annotations will be ignored during
+	 * instrumentation
+	 */
+	private Set<String> ignoreClassAnnotations = new HashSet<String>();
+
+	/**
 	 * If true: Getters, Setters and simple initialization will be ignored by coverage measurement
 	 */
 	private boolean ignoreTrivial;
@@ -157,7 +163,8 @@ public class CoberturaInstrumenter {
 		ClassReader cr = new ClassReader(cw0.toByteArray());
 		ClassWriter cw = new ClassWriter(0);
 		BuildClassMapClassVisitor cv = new BuildClassMapClassVisitor(cw,
-				ignoreRegexes, cv0.getDuplicatesLinesCollector(),
+				ignoreRegexes, ignoreClassAnnotations,
+				cv0.getDuplicatesLinesCollector(),
 				detectIgnoredCv.getIgnoredMethodNamesAndSignatures());
 
 		cr.accept(cv, ClassReader.EXPAND_FRAMES);
@@ -191,8 +198,8 @@ public class CoberturaInstrumenter {
 
 		if (cv.shouldBeInstrumented()) {
 			/*
-			 *  BuildClassMapClassInstrumenter and DetectDuplicatedCodeClassVisitor has not modificated bytecode, 
-			 *  so we can use any bytecode representation of that class. 
+			 *  BuildClassMapClassInstrumenter and DetectDuplicatedCodeClassVisitor has not modificated bytecode,
+			 *  so we can use any bytecode representation of that class.
 			 */
 			ClassReader cr2 = new ClassReader(cw0.toByteArray());
 			ClassWriter cw2 = new CoberturaClassWriter(
@@ -265,7 +272,7 @@ public class CoberturaInstrumenter {
 		}
 	}
 
-	// ----------------- Getters and setters -------------------------------------	
+	// ----------------- Getters and setters -------------------------------------
 
 	/**
 	 * Gets the root directory for instrumented classes. If it is null, the instrumented classes are overwritten.
@@ -301,6 +308,10 @@ public class CoberturaInstrumenter {
 
 	public void setIgnoreMethodAnnotations(Set<String> ignoreMethodAnnotations) {
 		this.ignoreMethodAnnotations = ignoreMethodAnnotations;
+	}
+
+	public void setIgnoreClassAnnotations(Set<String> ignoreClassAnnotations) {
+		this.ignoreClassAnnotations = ignoreClassAnnotations;
 	}
 
 	public void setThreadsafeRigorous(boolean threadsafeRigorous) {

--- a/cobertura/src/main/java/net/sourceforge/cobertura/instrument/CodeInstrumentationTask.java
+++ b/cobertura/src/main/java/net/sourceforge/cobertura/instrument/CodeInstrumentationTask.java
@@ -68,6 +68,8 @@ public class CodeInstrumentationTask {
 		coberturaInstrumenter.setIgnoreTrivial(arguments.isIgnoreTrivial());
 		coberturaInstrumenter.setIgnoreMethodAnnotations(arguments
 				.getIgnoreMethodAnnotations());
+		coberturaInstrumenter.setIgnoreClassAnnotations(arguments
+				.getIgnoreClassAnnotations());
 		coberturaInstrumenter.setThreadsafeRigorous(arguments
 				.isThreadsafeRigorous());
 		coberturaInstrumenter.setFailOnError(arguments.isFailOnError());

--- a/cobertura/src/main/java/net/sourceforge/cobertura/instrument/InstrumentMain.java
+++ b/cobertura/src/main/java/net/sourceforge/cobertura/instrument/InstrumentMain.java
@@ -108,6 +108,8 @@ public class InstrumentMain {
 				builder.addIgnoreRegex(args[++i]);
 			} else if (args[i].equals("--ignoreMethodAnnotation")) {
 				builder.addIgnoreMethodAnnotation(args[++i]);
+			} else if (args[i].equals("--ignoreClassAnnotation")) {
+				builder.addIgnoreClassAnnotation(args[++i]);
 			} else if (args[i].equals("--ignoreTrivial")) {
 				builder.ignoreTrivial(true);
 			} else if (args[i].equals("--includeClasses")) {

--- a/cobertura/src/test/java/net/sourceforge/cobertura/dsl/ArgumentsBuilderTest.java
+++ b/cobertura/src/test/java/net/sourceforge/cobertura/dsl/ArgumentsBuilderTest.java
@@ -73,6 +73,14 @@ public class ArgumentsBuilderTest {
 	}
 
 	@Test
+	public void testAddIgnoreClassAnnotation() throws Exception {
+		String someValue = "someValue";
+		assertEquals(someValue, new ArgumentsBuilder()
+				.addIgnoreClassAnnotation(someValue).build()
+				.getIgnoreClassAnnotations().iterator().next());
+	}
+
+    @Test
 	public void testAddExcludeClassesRegex() throws Exception {
 		String someRegex = "someRegex";
 		assertEquals(someRegex, new ArgumentsBuilder().addExcludeClassesRegex(
@@ -287,6 +295,8 @@ public class ArgumentsBuilderTest {
 		assertTrue(defaultArgs.getIgnoreBranchesRegexes().isEmpty());
 		assertNotNull(defaultArgs.getIgnoreMethodAnnotations());
 		assertTrue(defaultArgs.getIgnoreMethodAnnotations().isEmpty());
+		assertNotNull(defaultArgs.getIgnoreClassAnnotations());
+		assertTrue(defaultArgs.getIgnoreClassAnnotations().isEmpty());
 		assertNotNull(defaultArgs.getClassPatternExcludeClassesRegexes());
 		assertTrue(defaultArgs.getClassPatternExcludeClassesRegexes().isEmpty());
 		assertNotNull(defaultArgs.getClassPatternIncludeClassesRegexes());

--- a/cobertura/src/test/java/net/sourceforge/cobertura/dsl/ArgumentsTest.java
+++ b/cobertura/src/test/java/net/sourceforge/cobertura/dsl/ArgumentsTest.java
@@ -44,6 +44,7 @@ public class ArgumentsTest {
 			".", "fileToInstrument");
 	private static final File FILE_TO_MERGE = new File("fileToMerge");
 	private static final String IGNORE_METHOD_ANNOTATIONS = "ignoreMethodAnnotations";
+	private static final String IGNORE_CLASS_ANNOTATIONS = "ignoreClassAnnotations";
 	private static final FileFinder SOURCES = new FileFinder();
 	private static final double DELTA = 0.001;
 	private Arguments arguments;
@@ -56,6 +57,7 @@ public class ArgumentsTest {
 	private Set<CoberturaFile> filesToInstrument = new HashSet<CoberturaFile>();
 	private Set<File> filesToMerge = new HashSet<File>();
 	private Set<String> ignoreMethodAnnotations = new HashSet<String>();
+	private Set<String> ignoreClassAnnotations = new HashSet<String>();
 
 	@Before
 	public void setUp() throws Exception {
@@ -71,6 +73,7 @@ public class ArgumentsTest {
 		filesToInstrument.add(FILE_TO_INSTRUMENT);
 		filesToMerge.add(FILE_TO_MERGE);
 		ignoreMethodAnnotations.add(IGNORE_METHOD_ANNOTATIONS);
+		ignoreClassAnnotations.add(IGNORE_CLASS_ANNOTATIONS);
 
 		this.arguments = new Arguments(BASEDIR, DATA_FILE,
 				DESTINATION_DIRECTORY, COMMANDS_FILE, ignoreRegexes,
@@ -81,7 +84,7 @@ public class ArgumentsTest {
 				CLASS_BRANCH_THRESHOLD, PACKAGE_LINE_THRESHOLD,
 				PACKAGE_BRANCH_THRESHOLD, TOTAL_LINE_THRESHOLD,
 				TOTAL_BRANCH_THRESHOLD, filesToInstrument, filesToMerge,
-				ignoreMethodAnnotations, SOURCES);
+				ignoreMethodAnnotations, ignoreClassAnnotations, SOURCES);
 	}
 
 	@Test
@@ -214,6 +217,12 @@ public class ArgumentsTest {
 	public void testGetIgnoreMethodAnnotations() throws Exception {
 		assertTrue(arguments.getIgnoreMethodAnnotations().contains(
 				IGNORE_METHOD_ANNOTATIONS));
+	}
+
+	@Test
+	public void testGetIgnoreClassAnnotations() throws Exception {
+		assertTrue(arguments.getIgnoreClassAnnotations().contains(
+				IGNORE_CLASS_ANNOTATIONS));
 	}
 
 	@Test


### PR DESCRIPTION
Some classes should be excluded from instrumentation and not always possible to use @CoverageIgnore . This enhancement allows to provide list of class annotations which will mark classes as toInstrument = false during class map building.
