### PR TITLE
Added maven profile for FreeBSD. Closes #121

### DIFF
--- a/cobertura/pom.xml
+++ b/cobertura/pom.xml
@@ -203,11 +203,23 @@
       </properties>
     </profile>
     <profile>
-      <id>UnixProfile</id>
+      <id>LinuxProfile</id>
       <activation>
         <os>
           <family>unix</family>
           <name>Linux</name>
+        </os>
+      </activation>
+      <properties>
+        <toolsjar>${java.home}/../lib/tools.jar</toolsjar>
+      </properties>
+    </profile>
+    <profile>
+      <id>FreeBSDProfile</id>
+      <activation>
+        <os>
+          <family>unix</family>
+          <name>freebsd</name>
         </os>
       </activation>
       <properties>


### PR DESCRIPTION
Closes #121

There is a set of profiles in cobertura/pom.xml, that excludes non-Linux Unix-like OSes. Added an extra profile to support FreeBSD (did not want to change existing one to be more inclusive, so the patch stays conservative).
