### PR TITLE
Update ASM to 4.2, fix for issue #138

### DIFF
--- a/cobertura/pom.xml
+++ b/cobertura/pom.xml
@@ -34,7 +34,7 @@
   </pluginRepositories>
 
   <properties>
-    <asmVersion>4.1</asmVersion>
+    <asmVersion>4.2</asmVersion>
     <xercesVersion>2.11.0</xercesVersion>
     <xalanVersion>2.7.1</xalanVersion>
     <oroVersion>2.0.8</oroVersion>


### PR DESCRIPTION
Updated ASM dependency from 4.1 to 4.2, to prevent issues with Groovy inner classes.

ASM issue: 316380 Bug in org.objectweb.asm.util.CheckClassAdapter.visitInnerClass() regarding inner class name. http://forge.ow2.org/tracker/index.php?func=detail&aid=316380&group_id=23&atid=100023
