### PR TITLE
Added maven profile for Solaris. Closes #142

### DIFF
--- a/cobertura/pom.xml
+++ b/cobertura/pom.xml
@@ -203,7 +203,7 @@
       </properties>
     </profile>
     <profile>
-      <id>UnixProfile</id>
+      <id>LinuxProfile</id>
       <activation>
         <os>
           <family>unix</family>
@@ -215,6 +215,18 @@
       </properties>
     </profile>
     <profile>
+      <id>SolarisProfile</id>
+      <activation>
+        <os>
+          <family>unix</family>
+          <name>SunOS</name>
+        </os>
+      </activation>
+      <properties>
+        <toolsjar>${java.home}/../lib/tools.jar</toolsjar>
+      </properties>
+    </profile>    
+	<profile>
       <id>OSXProfile</id>
       <activation>
         <os>


### PR DESCRIPTION
Closes #142

There is a set of profiles in cobertura/pom.xml, that excludes non-Linux Unix-like OSes. Added an extra profile to support Solaris based on https://github.com/cobertura/cobertura/issues/121
