### PR TITLE
Fixed coverage rates specified in regexes - they were not working correctly.

### DIFF
--- a/cobertura/src/main/java/net/sourceforge/cobertura/check/CheckCoverageMain.java
+++ b/cobertura/src/main/java/net/sourceforge/cobertura/check/CheckCoverageMain.java
@@ -30,14 +30,11 @@ import net.sourceforge.cobertura.dsl.Cobertura;
 import net.sourceforge.cobertura.reporting.CoverageThresholdsReport;
 import net.sourceforge.cobertura.reporting.ReportName;
 import net.sourceforge.cobertura.util.Header;
-
 import org.apache.oro.text.regex.MalformedPatternException;
-import org.apache.oro.text.regex.Pattern;
-import org.apache.oro.text.regex.Perl5Compiler;
-import org.apache.oro.text.regex.Perl5Matcher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.StringTokenizer;
 
@@ -56,21 +53,21 @@ public class CheckCoverageMain {
 			CoverageResultEntry entry, int branchStatus, int lineStatus) {
 		if (entry.getCoverageType().equals(BRANCH)) {
 			logger
-					.error(String
-							.format(
-									"%s failed coverage check. Branch coverage rate of %s is below %s",
-									entry.getName(),
-									entry.getCurrentCoverage(), entry
-											.getExpectedCoverage()));
+					.error(entry.getName() +
+						   " failed coverage check. Branch coverage rate of "+
+						   percentage(entry.getCurrentCoverage()) +
+					       "% is below " +
+						   percentage(entry.getExpectedCoverage()) +
+						   "%");
 			return branchStatus;
 		} else {
 			logger
-					.error(String
-							.format(
-									"%s failed coverage check. Line coverage rate of %s is below %s",
-									entry.getName(),
-									entry.getCurrentCoverage(), entry
-											.getExpectedCoverage()));
+					.error(entry.getName() +
+						   " failed coverage check. Line coverage rate of " +
+						   percentage(entry.getCurrentCoverage()) +
+					       "% is below " +
+						   percentage(entry.getExpectedCoverage()) +
+					       "%");
 			return lineStatus;
 		}
 	}
@@ -92,6 +89,11 @@ public class CheckCoverageMain {
 				+ "% is invalid.  Percentages must be between 0 and 100.");
 	}
 
+    private static String percentage(double coverateRate) {
+        BigDecimal decimal = new BigDecimal(coverateRate * 100);
+        return decimal.setScale(1, BigDecimal.ROUND_DOWN).toString();
+    }
+
 	public static int checkCoverage(String[] args)
 			throws MalformedPatternException {
 		Header.print(System.out);
@@ -109,9 +111,9 @@ public class CheckCoverageMain {
 						.setClassLineCoverageThreshold(inRangeAndDivideByOneHundred(args[++i]));
 			} else if (args[i].equals("--regex")) {
 				StringTokenizer tokenizer = new StringTokenizer(args[++i], ":");
-				builder.addMinimumCoverageRates(tokenizer.nextToken(), Integer
-						.valueOf(tokenizer.nextToken()), Integer
-						.valueOf(tokenizer.nextToken()));
+				builder.addMinimumCoverageRates(tokenizer.nextToken(),
+						inRangeAndDivideByOneHundred(tokenizer.nextToken()),
+						inRangeAndDivideByOneHundred(tokenizer.nextToken()));
 			} else if (args[i].equals("--packagebranch")) {
 				builder
 						.setPackageBranchCoverageThreshold(inRangeAndDivideByOneHundred(args[++i]));

--- a/cobertura/src/main/java/net/sourceforge/cobertura/check/CoverageThreshold.java
+++ b/cobertura/src/main/java/net/sourceforge/cobertura/check/CoverageThreshold.java
@@ -5,8 +5,8 @@ package net.sourceforge.cobertura.check;
  */
 public class CoverageThreshold {
 	private String regex;
-	private int minBranchPercentage;
-	private int minLinePercentage;
+	private double minBranchPercentage;
+	private double minLinePercentage;
 
 	/**
 	 * Costructor
@@ -14,8 +14,8 @@ public class CoverageThreshold {
 	 * @param minBranchPercentage -minimum expected branch coverage percentage
 	 * @param minLinePercentage -minimum expected line coverage percentage
 	 */
-	public CoverageThreshold(String regex, int minBranchPercentage,
-			int minLinePercentage) {
+	public CoverageThreshold(String regex, double minBranchPercentage,
+			double minLinePercentage) {
 		this.regex = regex;
 		this.minBranchPercentage = minBranchPercentage;
 		this.minLinePercentage = minLinePercentage;
@@ -25,11 +25,11 @@ public class CoverageThreshold {
 		return regex;
 	}
 
-	public int getMinBranchPercentage() {
+	public double getMinBranchPercentage() {
 		return minBranchPercentage;
 	}
 
-	public int getMinLinePercentage() {
+	public double getMinLinePercentage() {
 		return minLinePercentage;
 	}
 }

--- a/cobertura/src/main/java/net/sourceforge/cobertura/dsl/ArgumentsBuilder.java
+++ b/cobertura/src/main/java/net/sourceforge/cobertura/dsl/ArgumentsBuilder.java
@@ -148,7 +148,7 @@ public class ArgumentsBuilder {
 	}
 
 	public ArgumentsBuilder addMinimumCoverageRates(String regex,
-			int branchPercentage, int linePercentage) {
+			double branchPercentage, double linePercentage) {
 		minimumCoverageThresholds.add(new CoverageThreshold(regex,
 				branchPercentage, linePercentage));
 		return this;

--- a/cobertura/src/test/java/net/sourceforge/cobertura/check/CoverageThresholdTest.java
+++ b/cobertura/src/test/java/net/sourceforge/cobertura/check/CoverageThresholdTest.java
@@ -7,9 +7,10 @@ import static org.junit.Assert.assertEquals;
 
 public class CoverageThresholdTest {
 
-	public static final int MIN_LINE_PERCENTAGE = 50;
-	public static final int MIN_BRANCH_PERCENTAGE = 50;
-	public static final String REGEX = "*";
+	private static final double MIN_LINE_PERCENTAGE = .5;
+	private static final double MIN_BRANCH_PERCENTAGE = .5;
+	private static final String REGEX = "*";
+	private static final double DELTA = .001;
 	private CoverageThreshold coverageThreshold;
 
 	@Before
@@ -26,12 +27,12 @@ public class CoverageThresholdTest {
 	@Test
 	public void testGetMinBranchPercentage() throws Exception {
 		assertEquals(MIN_BRANCH_PERCENTAGE, coverageThreshold
-				.getMinBranchPercentage());
+				.getMinBranchPercentage(), DELTA);
 	}
 
 	@Test
 	public void testGetMinLinePercentage() throws Exception {
 		assertEquals(MIN_LINE_PERCENTAGE, coverageThreshold
-				.getMinLinePercentage());
+				.getMinLinePercentage(), DELTA);
 	}
 }

--- a/cobertura/src/test/java/net/sourceforge/cobertura/dsl/ArgumentsBuilderTest.java
+++ b/cobertura/src/test/java/net/sourceforge/cobertura/dsl/ArgumentsBuilderTest.java
@@ -135,14 +135,14 @@ public class ArgumentsBuilderTest {
 	@Test
 	public void testAddMinimumCoverageRates() throws Exception {
 		String regex = "regex";
-		int lineCoverage = 50;
-		int branchCoverage = 55;
+		double lineCoverage = .5;
+		double branchCoverage = .55;
 		CoverageThreshold threshold = new ArgumentsBuilder()
 				.addMinimumCoverageRates(regex, branchCoverage, lineCoverage)
 				.build().getMinimumCoverageThresholds().iterator().next();
 		assertEquals(regex, threshold.getRegex());
-		assertEquals(lineCoverage, threshold.getMinLinePercentage());
-		assertEquals(branchCoverage, threshold.getMinBranchPercentage());
+		assertEquals(lineCoverage, threshold.getMinLinePercentage(), DELTA);
+		assertEquals(branchCoverage, threshold.getMinBranchPercentage(), DELTA);
 	}
 
 	@Test

--- a/cobertura/src/test/java/net/sourceforge/cobertura/dsl/ArgumentsTest.java
+++ b/cobertura/src/test/java/net/sourceforge/cobertura/dsl/ArgumentsTest.java
@@ -38,8 +38,8 @@ public class ArgumentsTest {
 	private static final String CLASS_PATTERN_INCLUDE_CLASSES_REGEXES = "classPatternIncludeClassesRegexes";
 	private static final String CLASS_PATTERN_EXCLUDE_CLASSES_REGEXES = "classPatternExcludeClassesRegexes";
 	private static final String COVERAGE_THRESHOLD_REGEX = "coverageThresholdRegex";
-	private static final int MIN_BRANCH_PERCENTAGE = 50;
-	private static final int MIN_LINE_PERCENTAGE = 50;
+	private static final double MIN_BRANCH_PERCENTAGE = .5;
+	private static final double MIN_LINE_PERCENTAGE = .5;
 	private static final CoberturaFile FILE_TO_INSTRUMENT = new CoberturaFile(
 			".", "fileToInstrument");
 	private static final File FILE_TO_MERGE = new File("fileToMerge");
@@ -161,8 +161,8 @@ public class ArgumentsTest {
 	public void testGetMinimumCoverageThresholds() throws Exception {
 		CoverageThreshold threshold = arguments.getMinimumCoverageThresholds()
 				.iterator().next();
-		assertEquals(MIN_LINE_PERCENTAGE, threshold.getMinLinePercentage());
-		assertEquals(MIN_BRANCH_PERCENTAGE, threshold.getMinBranchPercentage());
+		assertEquals(MIN_LINE_PERCENTAGE, threshold.getMinLinePercentage(), DELTA);
+		assertEquals(MIN_BRANCH_PERCENTAGE, threshold.getMinBranchPercentage(), DELTA);
 		assertEquals(COVERAGE_THRESHOLD_REGEX, threshold.getRegex());
 	}
 


### PR DESCRIPTION
The Check Coverage task has several arguments that configure acceptable branch and line coverage percentages.  In 2.0.3, they were all divided by 100 to give us a double, which was compared to the actual coverage.

In 2.1.0, the `int` percentages specified in a regex were passed on as is to the rest of Cobertura.  This resulted in coverage checks that can (almost) never pass, since the best we could do is 100% coverage, which is 1.0 as a number, which would be less than most percentages the user would give.  

This pull request properly divides these percentages by 100 (and checks the range) so that we get the right comparisons.

I also re-added the code that formatted the percentages as a number with one decimal place and a percent sign, as the old code did. 

This code 
