### PR TITLE
Activated the "FailOnError" flag for the Unit Test "instrumentExisting"

### DIFF
--- a/cobertura/src/test/java/net/sourceforge/cobertura/instrument/CoberturaInstrumenterTest.java
+++ b/cobertura/src/test/java/net/sourceforge/cobertura/instrument/CoberturaInstrumenterTest.java
@@ -44,15 +44,7 @@ public class CoberturaInstrumenterTest {
 	public void instrumentExisting() throws ClassNotFoundException {
 		coberturaInstrumenter.setDestinationDirectory(new File("target",
 				"build"));
-		coberturaInstrumenter.addInstrumentationToSingleClass(new File(
-				"src/test/resources/coberturaInstrumenterTest/Test1.class"));
-	}
-	
-	@Test
-	public void instrumentFailing() throws ClassNotFoundException {
 		coberturaInstrumenter.setFailOnError(true);
-		coberturaInstrumenter.setDestinationDirectory(new File("target",
-				"build"));
 		coberturaInstrumenter.addInstrumentationToSingleClass(new File(
 				"src/test/resources/coberturaInstrumenterTest/Test1.class"));
 	}


### PR DESCRIPTION
hey, 

the unit test "instrumentExisting" tries to instrument an existing classfile. However, in fact the classfile is not in the repository. Thereby the test should fail, it does not test the functionality it should test. Still, "FailOnError" is false, so the instrumentation fails silently and the test succeeds. Thereby the test is currently equivalent to "instrumentNotExisting", which certainly was not the intention of the test author. 

This commit sets the "FailOnError"-flag to "true". This makes sure that the test is failing if the input file is missing. 

In a future step, it is necessary to add the missing classfile. However, I can't do so as I do not have the file. 

Greetings, 
Alex

PS: I think there should also be a test for non-existing file and failOnError true, just to make sure the flag has the desired effect. 

PPS: It would be nice to check whether the instrumented class file is actually generated as well. 
