### PR TITLE
bugfix with instrumentalization inherited classes with static fields …

### DIFF
--- a/cobertura/.settings/org.eclipse.jdt.core.prefs
+++ b/cobertura/.settings/org.eclipse.jdt.core.prefs
@@ -1,5 +1,5 @@
-#Sun Jun 30 07:10:27 CDT 2013
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.5
 eclipse.preferences.version=1
-org.eclipse.jdt.core.compiler.source=1.5
-org.eclipse.jdt.core.compiler.compliance=1.5
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.6
+org.eclipse.jdt.core.compiler.compliance=1.6
+org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
+org.eclipse.jdt.core.compiler.source=1.6

--- a/cobertura/src/main/java/net/sourceforge/cobertura/instrument/pass3/InjectCodeClassInstrumenter.java
+++ b/cobertura/src/main/java/net/sourceforge/cobertura/instrument/pass3/InjectCodeClassInstrumenter.java
@@ -127,7 +127,7 @@ public class InjectCodeClassInstrumenter
 		if (ignoredMethods.contains(name + desc)) {
 			return mv;
 		}
-		if ((access & Opcodes.ACC_STATIC) != 0) {
+		if (((access & Opcodes.ACC_STATIC) != 0) || "<init>".equals(name)) {
 			mv = new GenerateCallCoberturaInitMethodVisitor(mv, classMap
 					.getClassName());
 			if ("<clinit>".equals(name)) {

--- a/cobertura/src/test/java/net/sourceforge/cobertura/test/ParentChildStaticFieldTest.java
+++ b/cobertura/src/test/java/net/sourceforge/cobertura/test/ParentChildStaticFieldTest.java
@@ -1,0 +1,151 @@
+/*
+ * The Apache Software License, Version 1.1
+ *
+ * Copyright (C) 2000-2002 The Apache Software Foundation.  All rights
+ * reserved.
+ * Copyright (C) 2010 John Lewis
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *
+ * 3. The end-user documentation included with the redistribution, if
+ *    any, must include the following acknowlegement:
+ *       "This product includes software developed by the
+ *        Apache Software Foundation (http://www.apache.org/)."
+ *    Alternately, this acknowlegement may appear in the software itself,
+ *    if and wherever such third-party acknowlegements normally appear.
+ *
+ * 4. The names "Ant" and "Apache Software
+ *    Foundation" must not be used to endorse or promote products derived
+ *    from this software without prior written permission. For written
+ *    permission, please contact apache@apache.org.
+ *
+ * 5. Products derived from this software may not be called "Apache"
+ *    nor may "Apache" appear in their names without prior written
+ *    permission of the Apache Group.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED.  IN NO EVENT SHALL THE APACHE SOFTWARE FOUNDATION OR
+ * ITS CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ * USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ */
+
+package net.sourceforge.cobertura.test;
+
+import groovy.util.AntBuilder;
+import groovy.util.Node;
+import net.sourceforge.cobertura.ant.ReportTask;
+import net.sourceforge.cobertura.test.util.TestUtils;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.tools.ant.taskdefs.Java;
+import org.apache.tools.ant.types.resources.FileResource;
+import org.junit.Test;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class ParentChildStaticFieldTest extends AbstractCoberturaTestCase {
+	AntBuilder ant = TestUtils.getCoberturaAntBuilder(TestUtils
+			.getCoberturaClassDir());
+
+	@Test
+	public void parentChildStaticFieldShouldWorkWithoutInstrumentalizationTest() throws Exception {
+		/*
+		 * Use a temporary directory and create a few sources files.
+		 */
+		File tempDir = TestUtils.getTempDir();
+		File srcDir = new File(tempDir, "src");
+		File instrumentDir = new File(tempDir, "instrument");
+
+		File mainSourceFile = new File(srcDir, "mypackage/ParentChildStaticField.java");
+		File datafile = new File(srcDir, "cobertura.ser");
+		mainSourceFile.getParentFile().mkdirs();
+
+		byte[] encoded =  Files.readAllBytes(Paths.get("src/test/resources/examples/basic/src/com/example/simple/ParentChildStaticFieldExample.java"));
+
+		FileUtils.write(mainSourceFile, new String(encoded, "utf8"));
+
+		TestUtils.compileSource(ant, srcDir);
+
+		/*
+		 * Kick off the Main (instrumented) class.
+		 */
+		Java java = new Java(); 
+		java.setProject(TestUtils.project);
+		java.setClassname("mypackage.ParentChildStaticField");
+		java.setDir(srcDir);
+		java.setFork(true);
+		java.setFailonerror(true);
+		java.setClasspath(TestUtils.getCoberturaDefaultClasspath());
+		java.execute();
+		
+
+	}
+@Test
+	public void parentChildStaticFieldShouldWorkAfterInstrumentalizationTest() throws Exception {
+		/*
+		 * Use a temporary directory and create a few sources files.
+		 */
+		File tempDir = TestUtils.getTempDir();
+		File srcDir = new File(tempDir, "src");
+		File instrumentDir = new File(tempDir, "instrument");
+
+		File mainSourceFile = new File(srcDir, "mypackage/ParentChildStaticField.java");
+		File datafile = new File(srcDir, "cobertura.ser");
+		mainSourceFile.getParentFile().mkdirs();
+
+		byte[] encoded =  Files.readAllBytes(Paths.get("src/test/resources/examples/basic/src/com/example/simple/ParentChildStaticFieldExample.java"));
+
+		FileUtils.write(mainSourceFile, new String(encoded, "utf8"));
+
+		TestUtils.compileSource(ant, srcDir);
+
+		TestUtils.instrumentClasses(ant, srcDir, datafile, instrumentDir);
+		
+		//moving instrumented classes so we don't have to change classpaths
+		FileUtils.copyDirectory(instrumentDir, srcDir);
+		
+		/*
+		 * Kick off the Main (instrumented) class.
+		 */
+		Java java = new Java(); 
+		java.setProject(TestUtils.project);
+		java.setClassname("mypackage.ParentChildStaticField");
+		java.setDir(srcDir);
+		java.setFork(true);
+		java.setFailonerror(true);
+		java.setClasspath(TestUtils.getCoberturaDefaultClasspath());
+		java.execute();
+		
+
+	}}

--- a/cobertura/src/test/resources/examples/basic/src/com/example/simple/ParentChildStaticFieldExample.java
+++ b/cobertura/src/test/resources/examples/basic/src/com/example/simple/ParentChildStaticFieldExample.java
@@ -1,0 +1,40 @@
+package mypackage;
+
+public class ParentChildStaticField {
+
+	public static void main(String[] args) {
+		System.out.println("main: new Child()");
+		new Child();
+	}
+}
+
+abstract class Parent {
+
+	public static Parent child = new Child();
+
+	public static Parent getChild() {
+		System.out.println("Parent.getChild()");
+		return child;
+	}
+
+	public Parent() {
+		System.out.println("Parent()");
+	}
+
+	static {
+		System.out.println("Parent.static");
+	}
+}
+
+class Child extends Parent {
+
+	public static String chieldField;
+
+	public Child() {
+		System.out.println("Child()");
+	}
+	static {
+		System.out.println("Child.static");
+	}
+}
+


### PR DESCRIPTION
There is a problem with construction:

class Parent {
static public Child = new Child();
Parent(){...}
...
}

class Child extends Parent
{
Child(){...}
...}

because instrumentalization creates static block at the end of class (because there is no static block at all) if you run new Child() you will run Parent() constructor before static block.
Because only in static (block and methods) there is initialization of cobertura counter you will get exception.
This fix adds initialization also to constructor so instrumentation won't cause exception on runtime.
There is also a test checking if code is runnable before and after initialization.