### PR TITLE
Line ending of .sh scripts and fix getting script directory

### DIFF
--- a/cobertura/executables/cobertura-check.sh
+++ b/cobertura/executables/cobertura-check.sh
@@ -1,2 +1,4 @@
-BASEDIR=`dirname $0`
-java -cp $BASEDIR/cobertura-${project.version}.jar:$BASEDIR/lib/asm-${asmVersion}.jar:$BASEDIR/lib/asm-tree-${asmVersion}.jar:$BASEDIR/lib/asm-commons-${asmVersion}.jar:$BASEDIR/lib/asm-util-${asmVersion}.jar:$BASEDIR/lib/commons-lang3-${commonslangVersion}.jar:$BASEDIR/lib/slf4j-api-${slf4jVersion}.jar:$BASEDIR/lib/logback-core-${logbackVersion}.jar:$BASEDIR/lib/logback-classic-${logbackVersion}.jar:$BASEDIR/lib/oro-${oroVersion}.jar net.sourceforge.cobertura.check.CheckCoverageMain $*
+#!/bin/bash
+COBERTURA_HOME=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+
+java -cp $COBERTURA_HOME/coberturatura-2.1.1.jar:$COBERTURA_HOME/lib/asm-5.0.1.jar:$COBERTURA_HOME/lib/asm-analysis-5.0.1.jar:$COBERTURA_HOME/lib/asm-tree-5.0.1.jar:$COBERTURA_HOME/lib/asm-commons-5.0.1.jar:$COBERTURA_HOME/lib/asm-util-5.0.1.jar:$COBERTURA_HOME/lib/slf4j-api-1.7.5.jar:$COBERTURA_HOME/lib/logback-core-1.0.13.jar:$COBERTURA_HOME/lib/logback-classic-1.0.13.jar:$COBERTURA_HOME/lib/oro-2.0.8.jar net.sourceforge.cobertura.instrument.InstrumentMain $*

--- a/cobertura/executables/cobertura-instrument.sh
+++ b/cobertura/executables/cobertura-instrument.sh
@@ -1,2 +1,4 @@
-BASEDIR=`dirname $0`
-java -cp $BASEDIR/cobertura-${project.version}.jar:$BASEDIR/lib/asm-${asmVersion}.jar:$BASEDIR/lib/asm-analysis-${asmVersion}.jar:$BASEDIR/lib/asm-tree-${asmVersion}.jar:$BASEDIR/lib/asm-commons-${asmVersion}.jar:$BASEDIR/lib/asm-util-${asmVersion}.jar:$BASEDIR/lib/slf4j-api-${slf4jVersion}.jar:$BASEDIR/lib/logback-core-${logbackVersion}.jar:$BASEDIR/lib/logback-classic-${logbackVersion}.jar:$BASEDIR/lib/oro-${oroVersion}.jar net.sourceforge.cobertura.instrument.InstrumentMain $*
+#!/bin/bash
+COBERTURA_HOME=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+
+java -cp $COBERTURA_HOME/cobertura-${project.version}.jar:$COBERTURA_HOME/lib/asm-${asmVersion}.jar:$COBERTURA_HOME/lib/asm-analysis-${asmVersion}.jar:$COBERTURA_HOME/lib/asm-tree-${asmVersion}.jar:$COBERTURA_HOME/lib/asm-commons-${asmVersion}.jar:$COBERTURA_HOME/lib/asm-util-${asmVersion}.jar:$COBERTURA_HOME/lib/slf4j-api-${slf4jVersion}.jar:$COBERTURA_HOME/lib/logback-core-${logbackVersion}.jar:$COBERTURA_HOME/lib/logback-classic-${logbackVersion}.jar:$COBERTURA_HOME/lib/oro-${oroVersion}.jar net.sourceforge.cobertura.instrument.InstrumentMain $*

--- a/cobertura/executables/cobertura-merge.sh
+++ b/cobertura/executables/cobertura-merge.sh
@@ -1,2 +1,4 @@
-BASEDIR=`dirname $0`
-java -cp $BASEDIR/cobertura-${project.version}.jar:$BASEDIR/lib/asm-${asmVersion}.jar:$BASEDIR/lib/asm-tree-${asmVersion}.jar:$BASEDIR/lib/asm-commons-${asmVersion}.jar:$BASEDIR/lib/slf4j-api-${slf4jVersion}.jar:$BASEDIR/lib/logback-core-${logbackVersion}.jar:$BASEDIR/lib/logback-classic-${logbackVersion}.jar:$BASEDIR/lib/oro-${oroVersion}.jar net.sourceforge.cobertura.merge.MergeMain $*
+#!/bin/bash
+COBERTURA_HOME=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+
+java -cp $COBERTURA_HOME/cobertura-${project.version}.jar:$COBERTURA_HOME/lib/asm-${asmVersion}.jar:$COBERTURA_HOME/lib/asm-tree-${asmVersion}.jar:$COBERTURA_HOME/lib/asm-commons-${asmVersion}.jar:$COBERTURA_HOME/lib/slf4j-api-${slf4jVersion}.jar:$COBERTURA_HOME/lib/logback-core-${logbackVersion}.jar:$COBERTURA_HOME/lib/logback-classic-${logbackVersion}.jar:$COBERTURA_HOME/lib/oro-${oroVersion}.jar net.sourceforge.cobertura.merge.MergeMain $*

--- a/cobertura/executables/cobertura-report.sh
+++ b/cobertura/executables/cobertura-report.sh
@@ -1,2 +1,4 @@
-BASEDIR=`dirname $0`
-java -cp $BASEDIR/cobertura-${project.version}.jar:$BASEDIR/lib/asm-${asmVersion}.jar:$BASEDIR/lib/asm-tree-${asmVersion}.jar:$BASEDIR/lib/asm-commons-${asmVersion}.jar:$BASEDIR/lib/asm-util-${asmVersion}.jar:$BASEDIR/lib/commons-lang3-${commonslangVersion}.jar:$BASEDIR/lib/slf4j-api-${slf4jVersion}.jar:$BASEDIR/lib/logback-core-${logbackVersion}.jar:$BASEDIR/lib/logback-classic-${logbackVersion}.jar:$BASEDIR/lib/oro-${oroVersion}.jar net.sourceforge.cobertura.reporting.ReportMain $*
+#!/bin/bash
+COBERTURA_HOME=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+
+java -cp $COBERTURA_HOME/cobertura-${project.version}.jar:$COBERTURA_HOME/lib/asm-${asmVersion}.jar:$COBERTURA_HOME/lib/asm-tree-${asmVersion}.jar:$COBERTURA_HOME/lib/asm-commons-${asmVersion}.jar:$COBERTURA_HOME/lib/asm-util-${asmVersion}.jar:$COBERTURA_HOME/lib/commons-lang3-${commonslangVersion}.jar:$COBERTURA_HOME/lib/slf4j-api-${slf4jVersion}.jar:$COBERTURA_HOME/lib/logback-core-${logbackVersion}.jar:$COBERTURA_HOME/lib/logback-classic-${logbackVersion}.jar:$COBERTURA_HOME/lib/oro-${oroVersion}.jar net.sourceforge.cobertura.reporting.ReportMain $*


### PR DESCRIPTION
The .sh executables didn't work well and it seemed like they were trying to pick up the script directory. Fixed to use BASH_SOURCE and changed from DOS to Unix line endings. 
