### PR TITLE
inefficient source code search in jar

### DIFF
--- a/cobertura/src/main/java/net/sourceforge/cobertura/util/FileFinder.java
+++ b/cobertura/src/main/java/net/sourceforge/cobertura/util/FileFinder.java
@@ -219,15 +219,9 @@ public class FileFinder {
 					try {
 						LOGGER.debug("Looking for: " + fileName + " in " + jar);
 						JarFile jf = new JarFile(directory + "/" + jar);
-
-						//Get a list of files in the jar
-						Enumeration<JarEntry> files = jf.entries();
-						//See if the jar has the class we need
-						while (files.hasMoreElements()) {
-							JarEntry entry = files.nextElement();
-							if (entry.getName().equals(fileName)) {
-								return new Source(jf.getInputStream(entry), jf);
-							}
+						JarEntry entry = jf.getJarEntry(fileName);
+						if (entry != null) {
+							return new Source(jf.getInputStream(entry), jf);
 						}
 					} catch (Throwable t) {
 						LOGGER.warn("Error while reading " + jar, t);


### PR DESCRIPTION
While creating coverage report, if source code is placed in jar, it's very inefficient to iterate all jar entry to find source code file.