### PR TITLE
Add call to __cobertura_init in constructors to avoid NPE

### DIFF
--- a/cobertura/src/main/java/net/sourceforge/cobertura/instrument/pass3/InjectCodeClassInstrumenter.java
+++ b/cobertura/src/main/java/net/sourceforge/cobertura/instrument/pass3/InjectCodeClassInstrumenter.java
@@ -127,7 +127,7 @@ public class InjectCodeClassInstrumenter
 		if (ignoredMethods.contains(name + desc)) {
 			return mv;
 		}
-		if ((access & Opcodes.ACC_STATIC) != 0) {
+		if ((access & Opcodes.ACC_STATIC) != 0 || "<init>".equals(name)) {
 			mv = new GenerateCallCoberturaInitMethodVisitor(mv, classMap
 					.getClassName());
 			if ("<clinit>".equals(name)) {


### PR DESCRIPTION
Add call to __cobertura_init() in constructors to avoid NPE when called before class initialization.
Fixes Issue #172 