### PR TITLE
Fix for #250 NullPointerException in TouchCollector

### DIFF
--- a/cobertura/src/main/java/net/sourceforge/cobertura/coveragedata/TouchCollector.java
+++ b/cobertura/src/main/java/net/sourceforge/cobertura/coveragedata/TouchCollector.java
@@ -37,9 +37,10 @@ import java.util.concurrent.ConcurrentHashMap;
 
 @CoverageIgnore
 public class TouchCollector {
-	private static final Logger logger = LoggerFactory.getLogger(TouchCollector.class);
 	/*In fact - concurrentHashset*/
 	private static Map<Class<?>, Integer> registeredClasses = new ConcurrentHashMap<Class<?>, Integer>();
+
+	private static final Logger logger = LoggerFactory.getLogger(TouchCollector.class);
 
 	static {
 		ProjectData.getGlobalProjectData(); // To call ProjectData.initialize();


### PR DESCRIPTION
The problem is that if the intrumented classes are using slf4j logger,
then we try to add it to registeredClasses which is not yet initialized
leading to NPE.
This change ensures that registeredClasses is initialized before the
logger.
