### PR TITLE
mark synthetic methods/fields with ACC_SYNTHETIC

### DIFF
--- a/cobertura/src/main/java/net/sourceforge/cobertura/instrument/pass3/AbstractCodeProvider.java
+++ b/cobertura/src/main/java/net/sourceforge/cobertura/instrument/pass3/AbstractCodeProvider.java
@@ -122,9 +122,10 @@ public abstract class AbstractCodeProvider implements CodeProvider {
 			parts++;
 		}
 
-		MethodVisitor mv = cv.visitMethod(Opcodes.ACC_PUBLIC
-				| Opcodes.ACC_STATIC, COBERTURA_CLASSMAP_METHOD_NAME, "("
-				+ Type.getType(LightClassmapListener.class).toString() + ")V",
+		MethodVisitor mv = cv.visitMethod(
+				Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC | Opcodes.ACC_SYNTHETIC,
+				COBERTURA_CLASSMAP_METHOD_NAME,
+				"(" + Type.getType(LightClassmapListener.class).toString() + ")V",
 				null, null);
 		mv.visitCode();
 		mv.visitVarInsn(Opcodes.ALOAD, 0);
@@ -163,8 +164,8 @@ public abstract class AbstractCodeProvider implements CodeProvider {
 
 	private void classMapContent(ClassVisitor cv, int nr,
 			List<TouchPointDescriptor> touchPointDescriptors) {
-		MethodVisitor mv = cv.visitMethod(Opcodes.ACC_PUBLIC
-				| Opcodes.ACC_STATIC,
+		MethodVisitor mv = cv.visitMethod(
+				Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC | Opcodes.ACC_SYNTHETIC,
 				COBERTURA_CLASSMAP_METHOD_NAME + "_" + nr, "("
 						+ Type.getType(LightClassmapListener.class).toString()
 						+ ")V", null, null);
@@ -244,8 +245,9 @@ public abstract class AbstractCodeProvider implements CodeProvider {
 
 	public void generateCoberturaInitMethod(ClassVisitor cv, String className,
 			int countersCnt) {
-		MethodVisitor mv = cv.visitMethod(Opcodes.ACC_PUBLIC
-				| Opcodes.ACC_STATIC, COBERTURA_INIT_METHOD_NAME, "()V", null,
+		MethodVisitor mv = cv.visitMethod(
+				Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC | Opcodes.ACC_SYNTHETIC,
+				COBERTURA_INIT_METHOD_NAME, "()V", null,
 				null);
 		mv.visitCode();
 		generateCINITmethod(mv, className, countersCnt);

--- a/cobertura/src/main/java/net/sourceforge/cobertura/instrument/pass3/AtomicArrayCodeProvider.java
+++ b/cobertura/src/main/java/net/sourceforge/cobertura/instrument/pass3/AtomicArrayCodeProvider.java
@@ -47,7 +47,7 @@ public class AtomicArrayCodeProvider extends AbstractCodeProvider
 
 	public void generateCountersField(ClassVisitor cv) {
 		FieldVisitor fv = cv.visitField(Opcodes.ACC_STATIC | Opcodes.ACC_PUBLIC
-				| Opcodes.ACC_FINAL | Opcodes.ACC_TRANSIENT,
+				| Opcodes.ACC_FINAL | Opcodes.ACC_TRANSIENT | Opcodes.ACC_SYNTHETIC,
 				COBERTURA_COUNTERS_FIELD_NAME, COBERTURA_COUNTERS_FIELD_TYPE,
 				null, null);
 		fv.visitEnd();
@@ -114,8 +114,8 @@ public class AtomicArrayCodeProvider extends AbstractCodeProvider
 	 */
 	public void generateCoberturaGetAndResetCountersMethod(ClassVisitor cv,
 			String className) {
-		MethodVisitor mv = cv.visitMethod(Opcodes.ACC_PUBLIC
-				| Opcodes.ACC_STATIC,
+		MethodVisitor mv = cv.visitMethod(
+				Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC | Opcodes.ACC_SYNTHETIC,
 				COBERTURA_GET_AND_RESET_COUNTERS_METHOD_NAME, "()[I", null,
 				null);
 

--- a/cobertura/src/main/java/net/sourceforge/cobertura/instrument/pass3/FastArrayCodeProvider.java
+++ b/cobertura/src/main/java/net/sourceforge/cobertura/instrument/pass3/FastArrayCodeProvider.java
@@ -96,7 +96,7 @@ public class FastArrayCodeProvider extends AbstractCodeProvider
 	public void generateCountersField(ClassVisitor cv) {
 		/*final tooks 270ms, no-modifier 310ms, volatile 500ms*/
 		FieldVisitor fv = cv.visitField(Opcodes.ACC_STATIC | Opcodes.ACC_PUBLIC
-				| Opcodes.ACC_FINAL | Opcodes.ACC_TRANSIENT,
+				| Opcodes.ACC_FINAL | Opcodes.ACC_TRANSIENT | Opcodes.ACC_SYNTHETIC,
 				COBERTURA_COUNTERS_FIELD_NAME, COBERTURA_COUNTERS_FIELD_TYPE,
 				null, null);
 		fv.visitEnd();
@@ -126,8 +126,8 @@ public class FastArrayCodeProvider extends AbstractCodeProvider
 
 	public void generateCoberturaGetAndResetCountersMethod(ClassVisitor cv,
 			String className) {
-		MethodVisitor mv = cv.visitMethod(Opcodes.ACC_PUBLIC
-				| Opcodes.ACC_STATIC,
+		MethodVisitor mv = cv.visitMethod(
+				Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC | Opcodes.ACC_SYNTHETIC,
 				COBERTURA_GET_AND_RESET_COUNTERS_METHOD_NAME, "()[I", null,
 				null);
 		mv.visitCode();

--- a/cobertura/src/main/java/net/sourceforge/cobertura/instrument/pass3/InjectCodeClassInstrumenter.java
+++ b/cobertura/src/main/java/net/sourceforge/cobertura/instrument/pass3/InjectCodeClassInstrumenter.java
@@ -176,7 +176,8 @@ public class InjectCodeClassInstrumenter
 	public void visitEnd() {
 		if (!wasStaticInitMethodVisited) {
 			//We need to generate new method
-			MethodVisitor mv = super.visitMethod(Opcodes.ACC_STATIC,
+			MethodVisitor mv = super.visitMethod(
+					Opcodes.ACC_STATIC | Opcodes.ACC_SYNTHETIC,
 					"<clinit>", "()V", null, null);
 			mv.visitCode();
 			codeProvider.generateCallCoberturaInitMethod(mv, classMap


### PR DESCRIPTION
Mark the fields and methods added by Cobertura as "synthetic".
This allows users to correctly tell if a given Field/Method is written in code or not.

https://docs.oracle.com/javase/specs/jvms/se7/html/jvms-4.html#jvms-4.7.8
> A class member that does not appear in the source code must be marked using a Synthetic attribute, or else it must have its ACC_SYNTHETIC flag set.
