### PR TITLE
Fix for 2 new bugs and some improvements

### DIFF
--- a/cobertura/pom.xml
+++ b/cobertura/pom.xml
@@ -61,7 +61,7 @@
     <plugin.mvn.jar.version>2.3.2</plugin.mvn.jar.version>
     <plugin.pmd.version>3.6</plugin.pmd.version>
     <plugin.jdoc.version>2.9.1</plugin.jdoc.version>
-    <plugin.findbugs.version>3.0.3</plugin.findbugs.version>
+    <plugin.findbugs.version>3.0.4</plugin.findbugs.version>
   </properties>
 
   <dependencies>

--- a/cobertura/src/main/java/net/sourceforge/cobertura/instrument/CoberturaInstrumenter.java
+++ b/cobertura/src/main/java/net/sourceforge/cobertura/instrument/CoberturaInstrumenter.java
@@ -211,7 +211,10 @@ public class CoberturaInstrumenter {
 					cw2, ignoreRegexes, threadsafeRigorous, cv.getClassMap(),
 					cv0.getDuplicatesLinesCollector(), detectIgnoredCv
 							.getIgnoredMethodNamesAndSignatures());
-			cr2.accept(new CheckClassAdapter(cv2), ClassReader.SKIP_FRAMES);
+			cr2.accept(new CheckClassAdapter(cv2), ClassReader.EXPAND_FRAMES);// if it is ClassReader.SKIP_FRAMES,
+                                                                                          // the InstrumentationBug1Test will fail as
+                                                                                          // the first pass has more counters than this pass
+                                                                                          // and there will be a mismatch when trying to find the counters
 			StringWriter sw = new StringWriter();
 			PrintWriter pw = new PrintWriter(sw);
 			CheckClassAdapter.verify(new ClassReader(cw2.toByteArray()), false,

--- a/cobertura/src/main/java/net/sourceforge/cobertura/instrument/pass1/DetectDuplicatedCodeMethodVisitor.java
+++ b/cobertura/src/main/java/net/sourceforge/cobertura/instrument/pass1/DetectDuplicatedCodeMethodVisitor.java
@@ -168,12 +168,12 @@ public class DetectDuplicatedCodeMethodVisitor
 
 	@Override
 	public void visitMethodInsn(int opCode, String className,
-			String methodName, String description) {
+			String methodName, String description, boolean bool) {
 		if (currentLineFootstamp != null) {
 			currentLineFootstamp.visitMethodInsn(opCode, className, methodName,
 					description);
 		}
-		super.visitMethodInsn(opCode, className, methodName, description);
+		super.visitMethodInsn(opCode, className, methodName, description, bool);
 	}
 
 	@Override

--- a/cobertura/src/main/javacc/Java1.1.jj
+++ b/cobertura/src/main/javacc/Java1.1.jj
@@ -2574,7 +2574,7 @@ void PrimarySuffix() :
 //  { System.out.println( "PrimarySuffix . Identifier()" ); }
   "." Identifier()
 |
-  Arguments()
+  Arguments() [ "{" MethodDeclaration() "}"]
 }
 
 void Literal() :

--- a/cobertura/src/main/javacc/Java1.1.jj
+++ b/cobertura/src/main/javacc/Java1.1.jj
@@ -3002,7 +3002,7 @@ void TryWithResources() :
 {}
 {
 //  LocalVariableDeclaration() [ ";" ]
-  LocalVariableDeclaration() ( ";" LocalVariableDeclaration() )*
+  LocalVariableDeclaration() ( LOOKAHEAD(2) ";" LocalVariableDeclaration() )* [ ";" ]
 }
 
 void Identifier() :

--- a/cobertura/src/main/javacc/Java1.1.jj
+++ b/cobertura/src/main/javacc/Java1.1.jj
@@ -2516,6 +2516,8 @@ void CastExpression() :
   LOOKAHEAD("(" PrimitiveType())
   "(" Type() ")" UnaryExpression()
 |
+  LOOKAHEAD(4) "(" Type() ")" LambdaExpression()
+|
   "(" Type() ")" UnaryExpressionNotPlusMinus()
 }
 

--- a/cobertura/src/main/javacc/Java1.1.jj
+++ b/cobertura/src/main/javacc/Java1.1.jj
@@ -2516,7 +2516,7 @@ void CastExpression() :
   LOOKAHEAD("(" PrimitiveType())
   "(" Type() ")" UnaryExpression()
 |
-  LOOKAHEAD(4) "(" Type() ")" LambdaExpression()
+  LOOKAHEAD("(" Type() ")" LambdaExpression()) "(" Type() ")" LambdaExpression()
 |
   "(" Type() ")" UnaryExpressionNotPlusMinus()
 }

--- a/cobertura/src/test/java/net/sourceforge/cobertura/bugs/GithubIssue109Test.java
+++ b/cobertura/src/test/java/net/sourceforge/cobertura/bugs/GithubIssue109Test.java
@@ -13,7 +13,7 @@ import org.junit.Test;
  * 
  * @author jad007
  */
-public class GithubIssue109 extends AbstractCoberturaTestCase
+public class GithubIssue109Test extends AbstractCoberturaTestCase
 {
 	@Test
 	public void testIssue109() throws IOException

--- a/cobertura/src/test/java/net/sourceforge/cobertura/bugs/GithubIssue170Test.java
+++ b/cobertura/src/test/java/net/sourceforge/cobertura/bugs/GithubIssue170Test.java
@@ -36,7 +36,7 @@ import static org.junit.Assert.assertTrue;
 /**
  * @author schristou88
  */
-public class GithubIssue170 extends AbstractCoberturaTestCase {
+public class GithubIssue170Test extends AbstractCoberturaTestCase {
     Node dom;
 
     @Override
@@ -58,7 +58,7 @@ public class GithubIssue170 extends AbstractCoberturaTestCase {
         assertEquals(2, TestUtils.getTotalHitCount(dom, "mypackage.GithubIssue170Test",
                 "<init>"));
         assertThat(TestUtils.getMethodBranchCoverage(dom, "mypackage.GithubIssue170Test",
-                "test170"), is(0.5));
+                "test170"), is(1.0));
     }
 
     static final String packageName = "mypackage";

--- a/cobertura/src/test/java/net/sourceforge/cobertura/bugs/GithubIssue191Test.java
+++ b/cobertura/src/test/java/net/sourceforge/cobertura/bugs/GithubIssue191Test.java
@@ -8,7 +8,7 @@ import java.io.IOException;
 /**
  * @author schristou88
  */
-public class GithubIssue191 extends AbstractCoberturaTestCase {
+public class GithubIssue191Test extends AbstractCoberturaTestCase {
     @Test
     public void testIssue191() throws IOException {
       String imports = "import java.io.*;" +

--- a/cobertura/src/test/java/net/sourceforge/cobertura/bugs/GithubIssue298Test.java
+++ b/cobertura/src/test/java/net/sourceforge/cobertura/bugs/GithubIssue298Test.java
@@ -10,7 +10,7 @@ import java.io.IOException;
  *         Date: 3/10/16
  *         Time: 12:24 AM
  */
-public class GithubIssue298 extends AbstractCoberturaTestCase {
+public class GithubIssue298Test extends AbstractCoberturaTestCase {
     @Test
     public void testIssue298() throws IOException {
         String imports = "import java.io.*;" +

--- a/cobertura/src/test/java/net/sourceforge/cobertura/bugs/GithubIssue30Test.java
+++ b/cobertura/src/test/java/net/sourceforge/cobertura/bugs/GithubIssue30Test.java
@@ -9,7 +9,7 @@ import org.junit.Test;
 import net.sourceforge.cobertura.test.AbstractCoberturaTestCase;
 import net.sourceforge.cobertura.test.util.TestUtils;
 
-public class GithubIssue30 extends AbstractCoberturaTestCase {
+public class GithubIssue30Test extends AbstractCoberturaTestCase {
 
 	Node dom;
 

--- a/cobertura/src/test/java/net/sourceforge/cobertura/bugs/GithubIssue37IT.java
+++ b/cobertura/src/test/java/net/sourceforge/cobertura/bugs/GithubIssue37IT.java
@@ -12,6 +12,7 @@ import java.util.jar.Manifest;
 import org.apache.commons.io.FileUtils;
 import org.junit.Test;
 
+// Shouldn't become a test. It checks the manifest of the cobertura.jar. Not a unit test.
 public class GithubIssue37IT {
 	@Test
 	public void testVersionCorrect() throws IOException {

--- a/cobertura/src/test/java/net/sourceforge/cobertura/bugs/GithubIssue42Test.java
+++ b/cobertura/src/test/java/net/sourceforge/cobertura/bugs/GithubIssue42Test.java
@@ -6,7 +6,7 @@ import org.junit.Test;
 
 import net.sourceforge.cobertura.test.AbstractCoberturaTestCase;
 
-public class GithubIssue42 extends AbstractCoberturaTestCase {
+public class GithubIssue42Test extends AbstractCoberturaTestCase {
 
 	@Test
 	public void testPlusEqualsParsing() throws IOException {

--- a/cobertura/src/test/java/net/sourceforge/cobertura/bugs/GithubIssue53Test.java
+++ b/cobertura/src/test/java/net/sourceforge/cobertura/bugs/GithubIssue53Test.java
@@ -13,7 +13,7 @@ import net.sourceforge.cobertura.test.AbstractCoberturaTestCase;
  * @author schristou88
  *
  */
-public class GithubIssue53 extends AbstractCoberturaTestCase {
+public class GithubIssue53Test extends AbstractCoberturaTestCase {
 	@Test
 	public void testInnersParsing() throws IOException {
 		String imports = "";

--- a/cobertura/src/test/java/net/sourceforge/cobertura/bugs/InstrumentationBug1Test.java
+++ b/cobertura/src/test/java/net/sourceforge/cobertura/bugs/InstrumentationBug1Test.java
@@ -1,0 +1,72 @@
+package net.sourceforge.cobertura.bugs;
+
+import static org.junit.Assert.*;
+
+import groovy.util.Node;
+
+import org.junit.Test;
+
+import net.sourceforge.cobertura.test.AbstractCoberturaTestCase;
+import net.sourceforge.cobertura.test.util.TestUtils;
+
+public class InstrumentationBug1Test extends AbstractCoberturaTestCase {
+
+	Node dom;
+
+	@Override
+	public void setUp() throws Exception {
+		super.setUp();
+
+		dom = super.createAndExecuteMainMethod(packageName, fileName, file1,
+				mainMethod);
+	}
+
+	@Test
+	public void testIssue() {
+		assertEquals(1, TestUtils.getTotalHitCount(dom,
+				"mypackage.CoverageBug",
+				"<clinit>"));
+		assertEquals(2, TestUtils.getTotalHitCount(dom,
+				"mypackage.CoverageBug",
+				"<init>"));
+		assertEquals(3, TestUtils.getTotalHitCount(dom,
+				"mypackage.CoverageBug",
+				"main"));
+		assertEquals(2, TestUtils.getTotalHitCount(dom, "mypackage.TestObject",
+				"<init>"));
+		assertEquals(2, TestUtils.getTotalHitCount(dom, "mypackage.CoverageBug",
+				"instanceMethod"));
+		assertEquals(4, TestUtils.getTotalHitCount(dom, "mypackage.CoverageBug",
+				"testMethod"));
+
+	}
+
+	static final String packageName = "mypackage";
+	static final String fileName = "CoverageBug";
+	static final String mainMethod = "mypackage.CoverageBug";
+	static final String file1 = "package mypackage;"
+			+ "public class CoverageBug {\n" +
+"\n" +
+"\n" +
+"    public static Object object = new Object();\n" +
+"\n" +
+"    public void instanceMethod(Object o) {\n" +
+"    }\n" +
+"\n" +
+"    public  boolean testMethod(boolean a) {\n" +
+"        instanceMethod(new TestObject(a ? 0 : 1));\n" +
+"        return a;\n" +
+"    }\n" +
+"\n" +
+"\n" +
+"    public static void main(String args[]) {\n" +
+"        new CoverageBug().testMethod(true);\n" +
+"        new CoverageBug().testMethod(false);\n" +
+"    }\n" +
+"}\n" +
+"\n" +
+"class TestObject {\n" +
+"\n" +
+"    public TestObject(int i) {}\n" +
+"}";
+}

--- a/cobertura/src/test/java/net/sourceforge/cobertura/reporting/ComplexityCalculator2Test.java
+++ b/cobertura/src/test/java/net/sourceforge/cobertura/reporting/ComplexityCalculator2Test.java
@@ -393,4 +393,37 @@ public class ComplexityCalculator2Test extends TestCase {
                 2.0, ccn1, 0.01);
     }
 
+
+    /**
+     * This test highlights an issue with Javancss not supporting java8 default method for interfaces.
+     * <p>
+     * @throws Exception
+     *                   <p>
+     */
+    public void testJava8LambdaConvertion() throws Exception {
+        File tempDir = TestUtils.getTempDir();
+        String filename = "LambdaConv.java";
+        File sourceFile = new File(tempDir, filename);
+        FileUtils
+                .write(
+                        sourceFile,
+                        "\n class LambdaConv {"
+                        + "\n void test(String str) {"
+                        + "\n Runnable runnable = (Runnable)() -> System.out.println(\"Test\");"
+                        + "\n }"
+                        + "}\n"
+                        );
+
+        //create a ComplexityCalculator that will use the archive
+        FileFinder fileFinder = new FileFinder();
+        fileFinder.addSourceDirectory(tempDir.getAbsolutePath());
+        ComplexityCalculator complexity = new ComplexityCalculator(fileFinder);
+
+        double ccn1 = complexity.getCCNForSourceFile(new SourceFileData(
+                filename));
+        assertNotNull(ccn1);
+        assertEquals(
+                "Testing lambda convertion",
+                1.0, ccn1, 0.01);
+    }
 }

--- a/cobertura/src/test/java/net/sourceforge/cobertura/reporting/ComplexityCalculator2Test.java
+++ b/cobertura/src/test/java/net/sourceforge/cobertura/reporting/ComplexityCalculator2Test.java
@@ -64,100 +64,102 @@ import org.junit.Test;
 import java.io.File;
 
 public class ComplexityCalculator2Test extends TestCase {
-	@Test
-	public void testSearchJarsForSourceInJar() throws Exception {
-		File tempDir = TestUtils.getTempDir();
-		File zipFile = TestUtils.createSourceArchive(tempDir);
 
-		//create a ComplexityCalculator that will use the archive
-		FileFinder fileFinder = new FileFinder();
-		fileFinder
-				.addSourceDirectory(zipFile.getParentFile().getAbsolutePath());
-		ComplexityCalculator complexity = new ComplexityCalculator(fileFinder);
+    @Test
+    public void testSearchJarsForSourceInJar() throws Exception {
+        File tempDir = TestUtils.getTempDir();
+        File zipFile = TestUtils.createSourceArchive(tempDir);
 
-		double ccn1 = complexity.getCCNForSourceFile(new SourceFileData(
-				TestUtils.SIMPLE_SOURCE_PATHNAME));
-		assertTrue(ccn1 == 1.0);
-	}
+        //create a ComplexityCalculator that will use the archive
+        FileFinder fileFinder = new FileFinder();
+        fileFinder
+                .addSourceDirectory(zipFile.getParentFile().getAbsolutePath());
+        ComplexityCalculator complexity = new ComplexityCalculator(fileFinder);
 
-	public void testAnnotatedSource() throws Exception {
-		/*
-		 * Test for bug #2818738.
-		 */
-		File tempDir = TestUtils.getTempDir();
-		String filename = "TBSException.java";
-		File sourceFile = new File(tempDir, filename);
-		FileUtils
-				.write(
-						sourceFile,
-						"\n public class TBSException extends Exception {"
-								+ "\n public TBSException (ErrorHandler handler, Exception wrap) {"
-								+ "\n super(wrap);"
-								+ "\n @SuppressWarnings(\"unchecked\")"
-								+ "\n final Iterator<Exception> iter = handler.getExceptions().iterator();  // LINE 27"
-								+ "\n for (; iter.hasNext();) " + "\n {"
-								+ "\n Exception exception = iter.next();"
-								+ "\n this.errors.add(exception.getMessage());"
-								+ "\n }" + "\n 	}" + "\n }");
+        double ccn1 = complexity.getCCNForSourceFile(new SourceFileData(
+                TestUtils.SIMPLE_SOURCE_PATHNAME));
+        assertTrue(ccn1 == 1.0);
+    }
 
-		//create a ComplexityCalculator that will use the archive
-		FileFinder fileFinder = new FileFinder();
-		fileFinder.addSourceDirectory(tempDir.getAbsolutePath());
-		ComplexityCalculator complexity = new ComplexityCalculator(fileFinder);
+    public void testAnnotatedSource() throws Exception {
+        /*
+         * Test for bug #2818738.
+         */
+        File tempDir = TestUtils.getTempDir();
+        String filename = "TBSException.java";
+        File sourceFile = new File(tempDir, filename);
+        FileUtils
+                .write(
+                        sourceFile,
+                        "\n public class TBSException extends Exception {"
+                        + "\n public TBSException (ErrorHandler handler, Exception wrap) {"
+                        + "\n super(wrap);"
+                        + "\n @SuppressWarnings(\"unchecked\")"
+                        + "\n final Iterator<Exception> iter = handler.getExceptions().iterator();  // LINE 27"
+                        + "\n for (; iter.hasNext();) " + "\n {"
+                        + "\n Exception exception = iter.next();"
+                        + "\n this.errors.add(exception.getMessage());"
+                        + "\n }" + "\n 	}" + "\n }");
 
-		double ccn1 = complexity.getCCNForSourceFile(new SourceFileData(
-				filename));
-		assertNotNull(ccn1);
-		assertEquals(2.0, ccn1, 0.01);
-	}
+        //create a ComplexityCalculator that will use the archive
+        FileFinder fileFinder = new FileFinder();
+        fileFinder.addSourceDirectory(tempDir.getAbsolutePath());
+        ComplexityCalculator complexity = new ComplexityCalculator(fileFinder);
 
-	/**
-	 * This test highlights an issue with Javancss.
-	 * 
-	 * http://jira.codehaus.org/browse/JAVANCSS-37
-	 * @throws Exception 
-	 * 
-	 */
-	public void testGenericsProblem() throws Exception {
-		File tempDir = TestUtils.getTempDir();
-		String filename = "UserAudit.java";
-		File sourceFile = new File(tempDir, filename);
-		FileUtils
-				.write(
-						sourceFile,
-						"\n import java.util.ArrayList;"
-								+ "\n import java.util.List;"
-								+ "\n "
-								+ "\n "
-								+ "\n public class UserAudit extends UserAuditParent {"
-								+ "\n void postCopyOnDestination(String str) throws InstantiationException, IllegalAccessException {"
-								+ "\n List<AllowedMMProduct> listToReset = new ArrayList<AllowedMMProduct>();"
-								+ "\n"
-								+ "\n List<AllowedMMProductAudit> auditProducts;"
-								+ "\n auditProducts = this.<AllowedMMProduct,AllowedMMProductAudit>copyListFromParent(AllowedMMProductAudit.class, getMmAuthorisedProducts_());"
-								+ "\n }"
-								+ "\n"
-								+ "\n List<AllowedMMProduct> getMmAuthorisedProducts_() {"
-								+ "\n return null;" + "\n 	}" + "\n }");
+        double ccn1 = complexity.getCCNForSourceFile(new SourceFileData(
+                filename));
+        assertNotNull(ccn1);
+        assertEquals(2.0, ccn1, 0.01);
+    }
 
-		//create a ComplexityCalculator that will use the archive
-		FileFinder fileFinder = new FileFinder();
-		fileFinder.addSourceDirectory(tempDir.getAbsolutePath());
-		ComplexityCalculator complexity = new ComplexityCalculator(fileFinder);
+    /**
+     * This test highlights an issue with Javancss.
+     * <p>
+     * http://jira.codehaus.org/browse/JAVANCSS-37
+     * <p>
+     * @throws Exception
+     * <p>
+     */
+    public void testGenericsProblem() throws Exception {
+        File tempDir = TestUtils.getTempDir();
+        String filename = "UserAudit.java";
+        File sourceFile = new File(tempDir, filename);
+        FileUtils
+                .write(
+                        sourceFile,
+                        "\n import java.util.ArrayList;"
+                        + "\n import java.util.List;"
+                        + "\n "
+                        + "\n "
+                        + "\n public class UserAudit extends UserAuditParent {"
+                        + "\n void postCopyOnDestination(String str) throws InstantiationException, IllegalAccessException {"
+                        + "\n List<AllowedMMProduct> listToReset = new ArrayList<AllowedMMProduct>();"
+                        + "\n"
+                        + "\n List<AllowedMMProductAudit> auditProducts;"
+                        + "\n auditProducts = this.<AllowedMMProduct,AllowedMMProductAudit>copyListFromParent(AllowedMMProductAudit.class, getMmAuthorisedProducts_());"
+                        + "\n }"
+                        + "\n"
+                        + "\n List<AllowedMMProduct> getMmAuthorisedProducts_() {"
+                        + "\n return null;" + "\n 	}" + "\n }");
 
-		double ccn1 = complexity.getCCNForSourceFile(new SourceFileData(
-				filename));
-		assertNotNull(ccn1);
-		assertEquals(
-				"Javancss issue has been fixed: http://jira.codehaus.org/browse/JAVANCSS-37.   Now fix this test.",
-                    1.0, ccn1, 0.01);
+        //create a ComplexityCalculator that will use the archive
+        FileFinder fileFinder = new FileFinder();
+        fileFinder.addSourceDirectory(tempDir.getAbsolutePath());
+        ComplexityCalculator complexity = new ComplexityCalculator(fileFinder);
+
+        double ccn1 = complexity.getCCNForSourceFile(new SourceFileData(
+                filename));
+        assertNotNull(ccn1);
+        assertEquals(
+                "Javancss issue has been fixed: http://jira.codehaus.org/browse/JAVANCSS-37.   Now fix this test.",
+                1.0, ccn1, 0.01);
     }
 
     /**
      * This test highlights an issue with Javancss not supporting java8 default method for interfaces.
      * <p>
      * @throws Exception
-     * <p>
+     *                   <p>
      */
     public void testJava8defaultAndStaticInterface() throws Exception {
         File tempDir = TestUtils.getTempDir();
@@ -351,6 +353,44 @@ public class ComplexityCalculator2Test extends TestCase {
         assertEquals(
                 "Testing method references and lambda functions",
                 1.875, ccn1, 0.01);
+    }
+
+    public void testJava7TryWithResourceEndingSemiColon() throws Exception {
+        File tempDir = TestUtils.getTempDir();
+        String filename = "DummyClass.java";
+        File sourceFile = new File(tempDir, filename);
+        FileUtils
+                .write(
+                        sourceFile,
+                        "\n public class DummyClass {"
+                        + "  public void baz2() {\n"
+                        + "	String zipFileName = \"\";\n"
+                        + "	String outputFileName = \"\";\n"
+                        + "	java.nio.charset.Charset charset = java.nio.charset.Charset.forName(\"US-ASCII\");\n"
+                        + "    java.nio.file.Path outputFilePath = java.nio.file.Paths.get(outputFileName);\n"
+                        + "	\n"
+                        + "	try (\n"
+                        + "      java.util.zip.ZipFile zf = new java.util.zip.ZipFile(zipFileName);\n"
+                        + "      java.io.BufferedWriter writer = java.nio.file.Files.newBufferedWriter(outputFilePath, charset);\n"
+                        + "    ) {\n"
+                        + "		// do nothing\n"
+                        + "	}\n"
+                        + "	catch (java.beans.PropertyVetoException e) {\n"
+                        + "		// do nothing\n"
+                        + "	}\n"
+                        + "  }}");
+
+        //create a ComplexityCalculator that will use the archive
+        FileFinder fileFinder = new FileFinder();
+        fileFinder.addSourceDirectory(tempDir.getAbsolutePath());
+        ComplexityCalculator complexity = new ComplexityCalculator(fileFinder);
+
+        double ccn1 = complexity.getCCNForSourceFile(new SourceFileData(
+                filename));
+        assertNotNull(ccn1);
+        assertEquals(
+                "Testing try with resource",
+                2.0, ccn1, 0.01);
     }
 
 }

--- a/cobertura/src/test/java/net/sourceforge/cobertura/test/AbstractCoberturaTestCase.java
+++ b/cobertura/src/test/java/net/sourceforge/cobertura/test/AbstractCoberturaTestCase.java
@@ -36,7 +36,7 @@ public class AbstractCoberturaTestCase {
 	public void setUp() throws Exception {
 		tempDir = TestUtils.getTempDir();
 
-		FileUtils.deleteDirectory(tempDir);
+                FileUtils.deleteDirectory(tempDir);
 
 		srcDir = new File(tempDir, "src");
 		reportDir = new File(tempDir, "report");
@@ -184,6 +184,8 @@ public class AbstractCoberturaTestCase {
 		} finally {
 			System.setErr(dErr);
 			System.setOut(dOut);
+                        err.close();
+                        out.close();
 		}
 	}
 }


### PR DESCRIPTION
Fix for a new bug (InstrumentationBug1Test).
Renamed most GithubIssue tests to be executed as unit tests and fixed closing the err and out streams at the end of the tests
Updated a deprecated function call.
Added back a fix to Java1.1.jj, which was accidentally removed before, but the GithubIssue53 test showed the problem again