### PR TITLE
Bump slf4j version to a more recent one

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
         <logbackVersion>1.0.13</logbackVersion>
         <junitVersion>4.12</junitVersion>
         <mockitoVersion>1.9.5</mockitoVersion>
-        <slf4jVersion>1.7.5</slf4jVersion>
+        <slf4jVersion>1.7.16</slf4jVersion>
         <jdomVersion>1.1.3</jdomVersion>
     
         <!--


### PR DESCRIPTION
Versions preceding 1.7.12 are not compatible with 1.7.13 or after. Bumping to a more recent and stable version. Tested locally.