### PR TITLE
use github actions for maven build (JDK 7 to 14)

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,21 @@
+name: Java CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: Test with Java ${{ matrix.jdk }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        jdk: ['1.7', '1.8', '9', '10', '11', '12', '13', '14']
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Set up JDK ${{ matrix.jdk }}
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.jdk }}
+      - name: Build with Maven # ideally do mvn verify but changes are needed first
+        run: mvn -B package --file pom.xml


### PR DESCRIPTION
This PR adds Github Actions to do a `mvn package` with JDK 7 through to JDK 14. Obviously most of these fail currently but at least there's more visibility on the problem.

![cobertura_build](https://user-images.githubusercontent.com/870567/81391927-d27d7700-9115-11ea-81f8-87516749ef2b.png)
